### PR TITLE
feat: Implement Integrated Gradients for MNIST CNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # deep_explain
 Making AI explainable
+
+## Explainable AI (XAI)
+Explainable AI (XAI) refers to methods and techniques that make the decisions and predictions of artificial intelligence systems understandable to humans. As AI models become increasingly complex (often referred to as "black boxes"), the need for transparency and interpretability grows. XAI is crucial for building trust, ensuring fairness, identifying potential biases, and enabling the robust and ethical deployment of AI systems across various domains.
+
+## Common XAI Techniques
+
+XAI techniques can be broadly categorized based on their applicability and how they derive explanations.
+
+### Model-Specific Techniques
+
+These methods are designed for a particular class of models. They leverage the internal structure or workings of the model to generate explanations.
+
+- **Integrated Gradients:** A technique that attributes the prediction of a deep neural network to its input features by accumulating gradients along the path from a baseline input to the actual input. Useful for understanding feature importance in deep learning models.
+- **Attention Mechanisms:** Originally developed for NLP and computer vision, attention mechanisms highlight which parts of the input data the model focused on when making a prediction. They provide insights into the model's decision-making process by showing salient input regions.
+
+### Model-Agnostic Techniques
+
+These methods can be applied to any AI model, as they treat the model as a black box. They typically work by perturbing the input and observing changes in the output.
+
+- **LIME (Local Interpretable Model-agnostic Explanations):** Explains the predictions of any classifier or regressor by approximating it locally with an interpretable model (e.g., linear model, decision tree). It helps understand why a specific prediction was made for a single instance.
+- **SHAP (SHapley Additive exPlanations):** A game theory approach to explain the output of any machine learning model. It assigns each feature an importance value (SHAP value) for a particular prediction, ensuring a consistent and locally accurate explanation.
+- **Counterfactual Explanations:** Describe the smallest change to the input features that would alter the prediction to a predefined output. They are human-friendly as they offer "what-if" scenarios (e.g., "Your loan application would have been approved if your income was $X higher").
+
+### Choosing the Right XAI Technique
+
+Selecting an appropriate XAI technique depends on several factors:
+
+- **Model Type:** Some techniques are model-specific (e.g., Integrated Gradients for neural networks), while others are model-agnostic (LIME, SHAP).
+- **Type of Data:** The nature of your data (e.g., images, text, tabular) can influence the suitability of an XAI method. For instance, attention mechanisms are common for image and text data.
+- **Explanation Desired:** What do you want to explain? Feature importance (SHAP, Integrated Gradients)? Local instance predictions (LIME)? Or "what-if" scenarios (Counterfactual Explanations)?
+- **Audience:** The technical background of the person receiving the explanation matters. Some explanations are more intuitive for non-experts (e.g., counterfactuals) than others (e.g., SHAP plots).
+- **Computational Cost:** Some XAI methods can be computationally intensive, especially for complex models or large datasets.
+
+## Further Reading and Resources
+
+This field is rapidly evolving. For deeper insights and the latest developments, consider exploring the following (contributions and suggestions for additional resources are welcome!):
+
+- Seminal research papers on specific XAI techniques.
+- Survey articles and books on Explainable AI.
+- Open-source libraries and tools for implementing XAI methods (e.g., SHAP library, LIME library, Captum).
+- Blog posts and articles from reputable AI research institutions and conferences.
+
+## Available Scripts and Examples
+
+### Integrated Gradients on MNIST
+
+-   **Script:** `run_integrated_gradients.py`
+-   **Description:** This script provides a demonstration of the Integrated Gradients technique for explaining predictions of a Convolutional Neural Network (CNN) trained on the MNIST handwritten digit dataset. It will:
+    1.  Load or train a CNN model.
+    2.  Select a sample digit from the test set.
+    3.  Compute Integrated Gradients to understand which pixels contributed most to the model's prediction.
+    4.  Save a visualization of the original digit and its attribution map to `integrated_gradients_visualization.png`.
+-   **Dependencies:** Required Python packages are listed in `requirements.txt`. Install them using:
+    ```bash
+    pip install -r requirements.txt
+    ```
+-   **How to run:**
+    ```bash
+    python run_integrated_gradients.py
+    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+tensorflow
+numpy
+matplotlib

--- a/run_integrated_gradients.py
+++ b/run_integrated_gradients.py
@@ -1,0 +1,190 @@
+# Script to implement and demonstrate Integrated Gradients
+
+import tensorflow as tf
+import numpy as np
+import matplotlib.pyplot as plt
+
+def load_and_preprocess_dataset():
+    # Load MNIST dataset from Keras
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
+
+    # Preprocess the data:
+    x_train = x_train.astype('float32') / 255.0
+    x_test = x_test.astype('float32') / 255.0
+    x_train = np.expand_dims(x_train, -1)
+    x_test = np.expand_dims(x_test, -1)
+
+    num_classes = 10
+    y_train = tf.keras.utils.to_categorical(y_train, num_classes)
+    y_test = tf.keras.utils.to_categorical(y_test, num_classes)
+
+    print("MNIST dataset loaded and preprocessed.")
+    print(f"x_train shape: {x_train.shape}, y_train shape: {y_train.shape}")
+    print(f"x_test shape: {x_test.shape}, y_test shape: {y_test.shape}")
+    return (x_train, y_train), (x_test, y_test)
+
+def get_model(input_shape, num_classes):
+    model = tf.keras.Sequential([
+        tf.keras.layers.Conv2D(32, kernel_size=(3, 3), activation='relu', input_shape=input_shape),
+        tf.keras.layers.MaxPooling2D(pool_size=(2, 2)),
+        tf.keras.layers.Conv2D(64, kernel_size=(3, 3), activation='relu'),
+        tf.keras.layers.MaxPooling2D(pool_size=(2, 2)),
+        tf.keras.layers.Flatten(),
+        tf.keras.layers.Dropout(0.5),
+        tf.keras.layers.Dense(num_classes, activation='softmax')
+    ])
+    return model
+
+def train_model(x_train, y_train, x_test, y_test, model_path='mnist_cnn_model.keras'):
+    input_shape = x_train.shape[1:]
+    num_classes = y_train.shape[1]
+    model = get_model(input_shape, num_classes)
+    model.compile(optimizer='adam',
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+    print("Training the model...")
+    model.fit(x_train, y_train,
+              batch_size=128,
+              epochs=5, # Reduced for speed
+              validation_data=(x_test, y_test))
+    score = model.evaluate(x_test, y_test, verbose=0)
+    print(f'Test loss: {score[0]}')
+    print(f'Test accuracy: {score[1]}')
+    model.save(model_path)
+    print(f"Model saved to {model_path}")
+    return model
+
+def integrated_gradients(model, input_image, target_class_index, baseline, m_steps=100):
+    input_image = tf.convert_to_tensor(input_image)
+    baseline = tf.convert_to_tensor(baseline)
+    alphas = tf.linspace(start=0.0, stop=1.0, num=m_steps + 1)
+    gradient_sum = tf.zeros_like(input_image, dtype=tf.float32)
+
+    for i in range(m_steps + 1):
+        alpha = alphas[i]
+        interpolated_image = baseline + alpha * (input_image - baseline)
+        with tf.GradientTape() as tape:
+            tape.watch(interpolated_image)
+            predictions = model(interpolated_image, training=False)
+            target_output = predictions[:, target_class_index]
+        gradients = tape.gradient(target_output, interpolated_image)
+        if gradients is not None:
+            gradient_sum += gradients
+        else:
+            print(f"Warning: Gradients are None for alpha = {alpha.numpy()}. Skipping.")
+    
+    if m_steps > 0:
+        avg_gradients = gradient_sum / tf.cast(m_steps, tf.float32)
+    else:
+        avg_gradients = gradient_sum 
+    attributions = (input_image - baseline) * avg_gradients
+    return attributions.numpy()
+
+def visualize_attributions(original_image, attributions, title="Integrated Gradients Attributions"):
+    if original_image.ndim == 4 and original_image.shape[0] == 1:
+        original_image_plot = np.squeeze(original_image, axis=0)
+    else:
+        original_image_plot = original_image
+    if attributions.ndim == 4 and attributions.shape[0] == 1:
+        attributions_plot = np.squeeze(attributions, axis=0)
+    else:
+        attributions_plot = attributions
+    if original_image_plot.ndim == 3 and original_image_plot.shape[-1] == 1:
+        original_image_plot = np.squeeze(original_image_plot, axis=-1)
+    if attributions_plot.ndim == 3 and attributions_plot.shape[-1] == 1:
+        attributions_plot = np.squeeze(attributions_plot, axis=-1)
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 5))
+    axes[0].imshow(original_image_plot, cmap='gray')
+    axes[0].set_title("Original Image")
+    axes[0].axis('off')
+    
+    abs_max = np.abs(attributions_plot).max()
+    if abs_max == 0: abs_max = 1.0
+    im = axes[1].imshow(attributions_plot, cmap='bwr', vmin=-abs_max, vmax=abs_max)
+    axes[1].set_title(title)
+    axes[1].axis('off')
+    fig.colorbar(im, ax=axes[1], orientation='vertical', fraction=0.046, pad=0.04)
+    plt.tight_layout()
+    save_path = "integrated_gradients_visualization.png"
+    plt.savefig(save_path)
+    print(f"Attribution visualization saved to {save_path}")
+    plt.close(fig)
+
+def run_mnist_integrated_gradients_example():
+    """
+    Runs a demonstration of Integrated Gradients on the MNIST dataset.
+    This includes:
+    1. Loading and preprocessing the MNIST dataset.
+    2. Loading a pre-trained CNN model or training a new one.
+    3. Selecting a sample image from the test set.
+    4. Computing Integrated Gradients for the model's prediction on the sample image.
+    5. Visualizing the original image and its attributions, then saving the plot.
+    """
+    print("Starting MNIST Integrated Gradients example...")
+    print("This script will load/train a CNN, pick an MNIST test image,")
+    print("compute Integrated Gradients for that image, and save the resulting")
+    print("visualization to 'integrated_gradients_visualization.png'.")
+
+    # Step 1: Load and preprocess the MNIST dataset
+    # This function handles loading, normalization, and reshaping of MNIST data.
+    (x_train, y_train), (x_test, y_test) = load_and_preprocess_dataset()
+
+    # Step 2: Load a pre-trained model or train a new one
+    # The model is a simple CNN for MNIST classification.
+    # If a saved model ('mnist_cnn_model.keras') exists, it's loaded; otherwise,
+    # the script trains a new model and saves it.
+    model_path = 'mnist_cnn_model.keras'
+    try:
+        trained_model = tf.keras.models.load_model(model_path)
+        print(f"Loaded trained model from {model_path}")
+    except IOError:
+        print(f"Model not found at {model_path}. Training a new model...")
+        trained_model = train_model(x_train, y_train, x_test, y_test, model_path)
+
+    # Step 3: Select a sample image and define a baseline
+    # We'll use the first image from the test set for this example.
+    # The baseline is a black image (all zeros), a common choice for IG.
+    sample_img_index = 0 
+    sample_image = x_test[sample_img_index:sample_img_index+1].astype('float32') # Ensure batch dim and float32
+    sample_label_one_hot = y_test[sample_img_index:sample_img_index+1]
+    sample_label_index = np.argmax(sample_label_one_hot) # True label
+    baseline_image = np.zeros_like(sample_image, dtype=np.float32)
+
+    # Step 4: Make a prediction and print information
+    # This helps confirm the model's prediction for the chosen sample.
+    print(f"\nExplaining prediction for image at index {sample_img_index} from the test set.")
+    print(f"True label of the image: {sample_label_index}")
+    
+    predictions = trained_model(sample_image, training=False) # Get model's prediction
+    predicted_class_index = np.argmax(predictions[0])
+    prediction_confidence = predictions[0][predicted_class_index]
+    print(f"Model's predicted class: {predicted_class_index} with confidence: {prediction_confidence:.4f}")
+
+    # Step 5: Compute Integrated Gradients
+    # This is the core XAI technique. We compute attributions for the predicted class.
+    # m_steps defines the number of steps in the integration approximation.
+    print("\nComputing Integrated Gradients...")
+    attributions = integrated_gradients(
+        trained_model, 
+        sample_image, 
+        predicted_class_index, 
+        baseline_image, 
+        m_steps=100  # Number of steps for the approximation
+    )
+    print(f"Integrated Gradients computed. Attributions array shape: {attributions.shape}")
+    print(f"Attributions min: {np.min(attributions):.4f}, max: {np.max(attributions):.4f}, mean: {np.mean(attributions):.4f}")
+
+    # Step 6: Visualize the attributions
+    # This function plots the original image alongside its attribution map
+    # and saves it to a file.
+    print("\nVisualizing attributions and saving the plot...")
+    visualization_title = (f"Integrated Gradients for Predicted Class: {predicted_class_index} "
+                           f"(True Class: {sample_label_index})")
+    visualize_attributions(sample_image, attributions, title=visualization_title)
+    
+    print("\nMNIST Integrated Gradients example finished.")
+    print("Check 'integrated_gradients_visualization.png' for the output.")
+
+if __name__ == '__main__':
+    run_mnist_integrated_gradients_example()


### PR DESCRIPTION
Adds a Python script (`run_integrated_gradients.py`) that demonstrates the Integrated Gradients XAI technique.

The script performs the following:
1.  Loads and preprocesses the MNIST dataset.
2.  Defines and trains a Convolutional Neural Network (CNN) on MNIST, or loads a pre-trained model (`mnist_cnn_model.keras`) if available.
3.  Implements the Integrated Gradients algorithm to compute feature attributions for a sample MNIST digit prediction.
4.  Visualizes the original digit alongside its attribution map, saving the output to `integrated_gradients_visualization.png`.

A `requirements.txt` file has been added for necessary dependencies (TensorFlow, NumPy, Matplotlib).

The main `README.md` has been updated to include instructions on how to set up dependencies and run the example script.